### PR TITLE
fix: replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/infra/docker/dev/postgresHA.yml
+++ b/infra/docker/dev/postgresHA.yml
@@ -13,7 +13,7 @@ services:
     depends_on:
       - pg-0
   pg-0:
-    image: bitnami/postgresql-repmgr:14
+    image: soldevelo/postgresql-repmgr:14
     container_name: pg-0
     profiles:
       - base
@@ -34,7 +34,7 @@ services:
     networks:
       - ${NETWORK_APPLICATION}
   pg-1:
-    image: bitnami/postgresql-repmgr:14
+    image: soldevelo/postgresql-repmgr:14
     container_name: pg-1
     profiles:
       - base
@@ -55,7 +55,7 @@ services:
     networks:
       - ${NETWORK_APPLICATION}
   pgpool:
-    image: bitnami/pgpool:4
+    image: soldevelo/pgpool:4
     container_name: pgpool
     hostname: db
     profiles:


### PR DESCRIPTION
## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnami/postgresql-repmgr:14` → [`soldevelo/postgresql-repmgr:14`](https://hub.docker.com/r/soldevelo/postgresql-repmgr)
- `bitnami/pgpool:4` → [`soldevelo/pgpool:4`](https://hub.docker.com/r/soldevelo/pgpool)